### PR TITLE
Fixed treesitter/highlighter error

### DIFF
--- a/.config/nvim/lua/josean/plugins-setup.lua
+++ b/.config/nvim/lua/josean/plugins-setup.lua
@@ -87,9 +87,7 @@ return packer.startup(function(use)
   -- treesitter configuration
   use({
     "nvim-treesitter/nvim-treesitter",
-    run = function()
-      require("nvim-treesitter.install").update({ with_sync = true })
-    end,
+    run = ":TSUpdate",
   })
 
   -- auto closing


### PR DESCRIPTION
With the latest treesitter and nvim, we see some errors like https://github.com/nvim-treesitter/nvim-treesitter/issues/1201, to fix the issue, we just need to set `run = ":TSUpdate",`.