### PR TITLE
Update null-ls.lua

### DIFF
--- a/.config/nvim/lua/josean/plugins/lsp/null-ls.lua
+++ b/.config/nvim/lua/josean/plugins/lsp/null-ls.lua
@@ -16,7 +16,7 @@ null_ls.setup({
   -- setup formatters & linters
   sources = {
     --  to disable file types use
-    --  "formatting.prettier.with({disabled_filetypes: {}})" (see null-ls docs)
+    --  "formatting.prettier.with({disabled_filetypes = {}})" (see null-ls docs)
     formatting.prettier, -- js/ts formatter
     formatting.stylua, -- lua formatter
     diagnostics.eslint_d.with({ -- js/ts linter


### PR DESCRIPTION
change 'formatting.prettier.with({disabled_filetypes: {}})' to  'formatting.prettier.with({disabled_filetypes = {}}) to correct' for correct syntax. The original usage gives an error.