### PR TITLE
replace 'sumneko_lua' with 'lua_ls'

### DIFF
--- a/.config/nvim/lua/josean/plugins/lsp/lspconfig.lua
+++ b/.config/nvim/lua/josean/plugins/lsp/lspconfig.lua
@@ -90,7 +90,7 @@ lspconfig["emmet_ls"].setup({
 })
 
 -- configure lua server (with special settings)
-lspconfig["sumneko_lua"].setup({
+lspconfig["lua_ls"].setup({
   capabilities = capabilities,
   on_attach = on_attach,
   settings = { -- custom settings for lua

--- a/.config/nvim/lua/josean/plugins/lsp/mason.lua
+++ b/.config/nvim/lua/josean/plugins/lsp/mason.lua
@@ -26,7 +26,7 @@ mason_lspconfig.setup({
     "html",
     "cssls",
     "tailwindcss",
-    "sumneko_lua",
+    "lua_ls",
     "emmet_ls",
   },
   -- auto-install configured servers (with lspconfig)


### PR DESCRIPTION
After updating neovim (v0.9.0), I see the error message, `sumneko_lua is deprecated, use lua_ls instead`. Same with this Reddit article: https://www.reddit.com/r/neovim/comments/1107xiz/how_to_fix_sumneko_lua_is_deprecated_use_lua_ls/

This PR replaces `sumneko_lua` with `lua_ls`.