### PR TITLE
Tiny update to keys in vim-maximizer.lua to match lazy syntax

### DIFF
--- a/.config/nvim/lua/josean/plugins/vim-maximizer.lua
+++ b/.config/nvim/lua/josean/plugins/vim-maximizer.lua
@@ -1,6 +1,6 @@
 return {
   "szw/vim-maximizer",
   keys = {
-    { "<leader>sm", "<cmd>MaximizerToggle<CR>", { desc = "Maximize/minimize a split" } },
+    { "<leader>sm", "<cmd>MaximizerToggle<CR>", desc = "Maximize/minimize a split" },
   },
 }


### PR DESCRIPTION
Hi Josean, your videos are fantastic and an invaluable resource for learning the latest / greatest in the neovim world!

I watch your videos for new ideas for my own config and your recent video about Lazy included a mention of a great feature to lazy load based on a keymap being hit. I moved many plugins in my config to this method, but when running:

```:Telescope keymaps```

The description shows as `annonymous`:
![image](https://github.com/josean-dev/dev-environment-files/assets/57931354/0b73286d-6286-4e5f-ace8-b0d66f0826f6)

I double checked the [Lazy documentation](https://github.com/folke/lazy.nvim/blob/main/doc/lazy.nvim.txt#L266) for this and it seems the syntax is ever so slightly different. Once I updated it to match the syntax, it correctly shows up when I run `:Telescope keymaps`

![image](https://github.com/josean-dev/dev-environment-files/assets/57931354/65de4470-0b56-45b9-9ff2-d74829288063)

Thanks again for your hard work on teaching!
