### PR TITLE
Add mason_lspconfig default_handlers

### DIFF
--- a/.config/nvim/lua/josean/plugins/lsp/lspconfig.lua
+++ b/.config/nvim/lua/josean/plugins/lsp/lspconfig.lua
@@ -70,92 +70,72 @@ return {
       vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
     end
 
-    -- configure html server
-    lspconfig["html"].setup({
-      capabilities = capabilities,
-      on_attach = on_attach,
-    })
+    local function default_handler(server_name, capabilities)
+      require("lspconfig")[server_name].setup({
+        capabilities = capabilities,
+        on_attach = on_attach,
+      })
+    end
 
-    -- configure typescript server with plugin
-    lspconfig["tsserver"].setup({
-      capabilities = capabilities,
-      on_attach = on_attach,
-    })
-
-    -- configure css server
-    lspconfig["cssls"].setup({
-      capabilities = capabilities,
-      on_attach = on_attach,
-    })
-
-    -- configure tailwindcss server
-    lspconfig["tailwindcss"].setup({
-      capabilities = capabilities,
-      on_attach = on_attach,
-    })
-
-    -- configure svelte server
-    lspconfig["svelte"].setup({
-      capabilities = capabilities,
-      on_attach = function(client, bufnr)
-        on_attach(client, bufnr)
-
-        vim.api.nvim_create_autocmd("BufWritePost", {
-          pattern = { "*.js", "*.ts" },
-          callback = function(ctx)
-            if client.name == "svelte" then
-              client.notify("$/onDidChangeTsOrJsFile", { uri = ctx.file })
-            end
+    lspconfig.setup_handlers({
+      function(server_name)
+        default_handler(server_name, capabilities)
+      end,
+      -- configure svelte language server
+      ["svelte"] = function()
+        lspconfig.svelte.setup({
+          capabilities = capabilities,
+          on_attach = function(client, bufnr)
+            on_attach(client, bufnr)
+            vim.api.nvim_create_autocmd("BufWritePost", {
+              pattern = { "*.js", "*.ts" },
+              callback = function(ctx)
+                if client.name == "svelte" then
+                  client.notify("$/onDidChangeTsOrJsFile", { uri = ctx.file })
+                end
+              end,
+            })
           end,
         })
       end,
-    })
-
-    -- configure prisma orm server
-    lspconfig["prismals"].setup({
-      capabilities = capabilities,
-      on_attach = on_attach,
-    })
-
-    -- configure graphql language server
-    lspconfig["graphql"].setup({
-      capabilities = capabilities,
-      on_attach = on_attach,
-      filetypes = { "graphql", "gql", "svelte", "typescriptreact", "javascriptreact" },
-    })
-
-    -- configure emmet language server
-    lspconfig["emmet_ls"].setup({
-      capabilities = capabilities,
-      on_attach = on_attach,
-      filetypes = { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less", "svelte" },
-    })
-
-    -- configure python server
-    lspconfig["pyright"].setup({
-      capabilities = capabilities,
-      on_attach = on_attach,
-    })
-
-    -- configure lua server (with special settings)
-    lspconfig["lua_ls"].setup({
-      capabilities = capabilities,
-      on_attach = on_attach,
-      settings = { -- custom settings for lua
-        Lua = {
-          -- make the language server recognize "vim" global
-          diagnostics = {
-            globals = { "vim" },
-          },
-          workspace = {
-            -- make language server aware of runtime files
-            library = {
-              [vim.fn.expand("$VIMRUNTIME/lua")] = true,
-              [vim.fn.stdpath("config") .. "/lua"] = true,
+      -- configure graphql language server
+      ["graphql"] = function()
+        lspconfig.graphql.setup({
+          capabilities = capabilities,
+          on_attach = on_attach,
+          filetypes = { "graphql", "gql", "svelte", "typescriptreact", "javascriptreact" },
+        })
+      end,
+      -- configure emmet language server
+      ["emmet_ls"] = function()
+        lspconfig.emmet_ls.setup({
+          capabilities = capabilities,
+          on_attach = on_attach,
+          filetypes = { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less", "svelte" },
+        })
+      end,
+      -- configure lua server (with special settings)
+      ["lua_ls"] = function()
+        lspconfig.lua_ls.setup({
+          capabilities = capabilities,
+          on_attach = on_attach,
+          settings = {
+            Lua = {
+              -- make the language server recognize "vim" global
+              diagnostics = {
+                globals = { "vim" },
+              },
+              workspace = {
+                -- make language server aware of runtime files
+                library = {
+                  [vim.fn.expand("$VIMRUNTIME/lua")] = true,
+                  [vim.fn.stdpath("config") .. "/lua"] = true,
+                },
+              },
             },
           },
-        },
-      },
+        })
+      end,
     })
   end,
 }

--- a/.config/nvim/lua/josean/plugins/lsp/lspconfig.lua
+++ b/.config/nvim/lua/josean/plugins/lsp/lspconfig.lua
@@ -77,7 +77,8 @@ return {
       })
     end
 
-    lspconfig.setup_handlers({
+    local mason_lspconfig = require("mason-lspconfig")
+    mason_lspconfig.setup_handlers({
       function(server_name)
         default_handler(server_name, capabilities)
       end,


### PR DESCRIPTION
## About
Add mason_lspconfig default_handlers instead of traditional nvim-lspconfig setup for each language.

## Benefits
This will make you have a default handler when you install a new language server, making it unecessary to setup a new nvim-lspconfig for each new language server that don't require a custom setup. You can still customize new language servers setup, passing a function to it's name's property in the setup_handlers argument table.