### PR TITLE
Update nvim-treesitter config to use new ts_context_commentstring setup

### DIFF
--- a/.config/nvim/lua/josean/plugins/nvim-treesitter.lua
+++ b/.config/nvim/lua/josean/plugins/nvim-treesitter.lua
@@ -52,12 +52,10 @@ return {
             node_decremental = "<bs>",
           },
         },
-        -- enable nvim-ts-context-commentstring plugin for commenting tsx and jsx
-        context_commentstring = {
-          enable = true,
-          enable_autocmd = false,
-        },
       })
+
+      -- enable nvim-ts-context-commentstring plugin for commenting tsx and jsx
+      require('ts_context_commentstring').setup {}
     end,
   },
 }


### PR DESCRIPTION
- Removed deprecated context_commentstring configuration from nvim-treesitter setup
- Added new ts_context_commentstring setup following the latest usage guidelines

It closes #51