### PR TITLE
Fix spacing of Find File and Quit NVIM buttons in the splash screen

### DIFF
--- a/.config/nvim/lua/josean/plugins/alpha.lua
+++ b/.config/nvim/lua/josean/plugins/alpha.lua
@@ -21,10 +21,10 @@ return {
     dashboard.section.buttons.val = {
       dashboard.button("e", "  > New File", "<cmd>ene<CR>"),
       dashboard.button("SPC ee", "  > Toggle file explorer", "<cmd>NvimTreeToggle<CR>"),
-      dashboard.button("SPC ff", "󰱼 > Find File", "<cmd>Telescope find_files<CR>"),
+      dashboard.button("SPC ff", "󰱼  > Find File", "<cmd>Telescope find_files<CR>"),
       dashboard.button("SPC fs", "  > Find Word", "<cmd>Telescope live_grep<CR>"),
       dashboard.button("SPC wr", "󰁯  > Restore Session For Current Directory", "<cmd>SessionRestore<CR>"),
-      dashboard.button("q", " > Quit NVIM", "<cmd>qa<CR>"),
+      dashboard.button("q", "  > Quit NVIM", "<cmd>qa<CR>"),
     }
 
     -- Send config to alpha


### PR DESCRIPTION
The splash screen created in `alpha.lua` has spacing issues in the `Find File` and `Quit NVIM` buttons. This PR updates the spacing.

Before:
<img width="538" alt="Screenshot 2024-04-03 at 4 09 02 PM" src="https://github.com/josean-dev/dev-environment-files/assets/19376865/3c949a40-8038-41b0-a24a-6ddf767c4266">

After:
<img width="512" alt="Screenshot 2024-04-03 at 4 10 06 PM" src="https://github.com/josean-dev/dev-environment-files/assets/19376865/978a0982-871f-432b-8e11-6f4235e8065f">
