### PR TITLE
Update substitute.lua for conciseness

### DIFF
--- a/.config/nvim/lua/josean/plugins/substitute.lua
+++ b/.config/nvim/lua/josean/plugins/substitute.lua
@@ -9,9 +9,9 @@ return {
     -- set keymaps
     local keymap = vim.keymap -- for conciseness
 
-    vim.keymap.set("n", "s", substitute.operator, { desc = "Substitute with motion" })
-    vim.keymap.set("n", "ss", substitute.line, { desc = "Substitute line" })
-    vim.keymap.set("n", "S", substitute.eol, { desc = "Substitute to end of line" })
-    vim.keymap.set("x", "s", substitute.visual, { desc = "Substitute in visual mode" })
+    keymap.set("n", "s", substitute.operator, { desc = "Substitute with motion" })
+    keymap.set("n", "ss", substitute.line, { desc = "Substitute line" })
+    keymap.set("n", "S", substitute.eol, { desc = "Substitute to end of line" })
+    keymap.set("x", "s", substitute.visual, { desc = "Substitute in visual mode" })
   end,
 }


### PR DESCRIPTION
    local keymap = vim.keymap -- for conciseness

was already set but not applied to the following keymaps. this fixes that.