### PR TITLE
Fix Sketchybar Youtube Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You'll also need to install extra cli tools as described in this blog post and v
 
 ✍🏼 Blog Post: [How To Make An Amazing Custom Menu Bar For Your Mac With Sketchybar](https://josean.com/posts/sketchybar-setup)
 
-📹 Youtube Guide: [How To Make An Amazing Custom Menu Bar For Your Mac With Sketchybar](https://youtu.be/k94qImbFKWE)
+📹 Youtube Guide: [How To Make An Amazing Custom Menu Bar For Your Mac With Sketchybar](https://youtu.be/8W06wMNZmo8)
 
 ### Setup Requires
 


### PR DESCRIPTION
The youtube link redirected to the yabai video instead of the sketchybar one...this is just a tiny patch to fix that.