### PR TITLE
fix: correct lsp_format opt

### DIFF
--- a/.config/nvim/lua/josean/plugins/formatting.lua
+++ b/.config/nvim/lua/josean/plugins/formatting.lua
@@ -22,7 +22,7 @@ return {
         python = { "isort", "black" },
       },
       format_on_save = {
-        lsp_fallback = true,
+        lsp_format = "callback",
         async = false,
         timeout_ms = 1000,
       },
@@ -30,7 +30,7 @@ return {
 
     vim.keymap.set({ "n", "v" }, "<leader>mp", function()
       conform.format({
-        lsp_fallback = true,
+        lsp_format = "callback",
         async = false,
         timeout_ms = 1000,
       })


### PR DESCRIPTION
HI ! Josean , Thank you for your amazing video.

[ref](https://github.com/stevearc/conform.nvim?tab=readme-ov-file#formatopts-callback)
It seems that the `lsp_fallback` opt already change to `lsp_format`.