### PR TITLE
fix: python linting doesn't resolve imports when venv is activated

### DIFF
--- a/.config/nvim/lua/josean/plugins/linting.lua
+++ b/.config/nvim/lua/josean/plugins/linting.lua
@@ -25,5 +25,8 @@ return {
     vim.keymap.set("n", "<leader>l", function()
       lint.try_lint()
     end, { desc = "Trigger linting for current file" })
+    
+    require('lint').linters.pylint.cmd = 'python'
+    require('lint').linters.pylint.args = {'-m', 'pylint', '-f', 'json'}    
   end,
 }


### PR DESCRIPTION
Found solution here - 

example - 
source .venv/bin/activate

In the vim buffer pylint says package not found
Apply fix below, the error goes away

https://stackoverflow.com/questions/78432883/python-virtual-environment-support-in-neovim
https://gist.githubusercontent.com/Norbiox/652befc91ca0f90014aec34eccee27b2/raw/4dba4f206c675bf5230f2360123e7c6a76f2701d/.lua