### PR TITLE
fix(tsserver-deprecation): use ts_ls where tsserver is being used in lspconfig

### DIFF
--- a/.config/nvim/lua/josean/plugins/lsp/lspconfig.lua
+++ b/.config/nvim/lua/josean/plugins/lsp/lspconfig.lua
@@ -81,6 +81,16 @@ return {
     mason_lspconfig.setup_handlers({
       -- default handler for installed servers
       function(server_name)
+        -- https://github.com/neovim/nvim-lspconfig/pull/3232#issuecomment-2331025714
+        if server_name == "tsserver" then
+          server_name = "ts_ls"
+        end
+        local capabilities = require("cmp_nvim_lsp").default_capabilities()
+        require("lspconfig")[server_name].setup({
+
+          capabilities = capabilities,
+        })
+
         lspconfig[server_name].setup({
           capabilities = capabilities,
         })


### PR DESCRIPTION
This PR addresses the following error when opening nvim:
**"tsserver is deprecated, use ts_ls instead. Feature will be removed in lspconfig 0.2.0"**

The issue was raised here:
https://github.com/josean-dev/dev-environment-files/issues/88 

The solution was given here:
https://github.com/neovim/nvim-lspconfig/pull/3232#issuecomment-2331025714

Note that you may need to do a reload of the related plugins:
`:Lazy reload mason.nvim mason-lspconfig.nvim mason-tool-installer.nvim`