### PR TITLE
Update mason.lua rename tsserver to ts_ls

### DIFF
--- a/.config/nvim/lua/josean/plugins/lsp/mason.lua
+++ b/.config/nvim/lua/josean/plugins/lsp/mason.lua
@@ -27,7 +27,7 @@ return {
     mason_lspconfig.setup({
       -- list of servers for mason to install
       ensure_installed = {
-        "tsserver",
+        "ts_ls",
         "html",
         "cssls",
         "tailwindcss",


### PR DESCRIPTION
https://github.com/williamboman/mason-lspconfig.nvim?tab=readme-ov-file#setup

Was updated with the new naming for tsserver, so we need to update the local mason config as well. If you update plugin from Lazy it will throw unrecognized "tsserver" errorr.