### PR TITLE
Add snippet navigation

### DIFF
--- a/.config/nvim/lua/josean/plugins/nvim-cmp.lua
+++ b/.config/nvim/lua/josean/plugins/nvim-cmp.lua
@@ -42,6 +42,22 @@ return {
         ["<C-Space>"] = cmp.mapping.complete(), -- show completion suggestions
         ["<C-e>"] = cmp.mapping.abort(), -- close completion window
         ["<CR>"] = cmp.mapping.confirm({ select = false }),
+        ["<Tab>"] = cmp.mapping(function(fallback) -- next part of snippet
+          if luasnip.expandable() then
+            luasnip.expand()
+          elseif luasnip.locally_jumpable(1) then
+            luasnip.jump(1)
+          else
+            fallback()
+          end
+        end, { "i", "s" }), -- in both insert and select mode
+        ["<S-Tab>"] = cmp.mapping(function(fallback) -- previous part of snippet
+          if luasnip.locally_jumpable(-1) then
+            luasnip.jump(-1)
+          else
+            fallback()
+          end
+        end, { "i", "s" }), -- in both insert and select mode
       }),
       -- sources for autocompletion
       sources = cmp.config.sources({


### PR DESCRIPTION
Adds the usage of `Tab` and `Shift-Tab` to jump through parts of the snippet after selecting one.

Pretty essential ^^