### PR TITLE
Update lspconfig.lua

### DIFF
--- a/.config/nvim/lua/josean/plugins/lsp/lspconfig.lua
+++ b/.config/nvim/lua/josean/plugins/lsp/lspconfig.lua
@@ -78,7 +78,7 @@ return {
       vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
     end
 
-    mason_lspconfig.setup_handlers({
+    mason_lspconfig.setup({handlers = { -- mason_lspconfig.setup_handlers doesn't exist but mason_lspconfig.setup({handlers = {}}) exists
       -- default handler for installed servers
       function(server_name)
         lspconfig[server_name].setup({
@@ -131,7 +131,7 @@ return {
           },
         })
       end,
-    })
+    }})
   end,
 }
 


### PR DESCRIPTION
setup_handlers is not a function of mason_lspconfig. can cause errors in newer mason with nvim in Mac using wezterm.