### PR TITLE
Update auto-session configuration (it was deprecated)

### DIFF
--- a/.config/nvim/lua/josean/plugins/auto-session.lua
+++ b/.config/nvim/lua/josean/plugins/auto-session.lua
@@ -1,16 +1,13 @@
 return {
   "rmagatti/auto-session",
   config = function()
-    local auto_session = require("auto-session")
-
-    auto_session.setup({
-      auto_restore_enabled = false,
-      auto_session_suppress_dirs = { "~/", "~/Dev/", "~/Downloads", "~/Documents", "~/Desktop/" },
+    require("auto-session").setup({
+      auto_restore = false,
+      suppressed_dirs = { "~/", "~/Dev/", "~/Downloads", "~/Documents", "~/Desktop/" },
     })
 
     local keymap = vim.keymap
-
-    keymap.set("n", "<leader>wr", "<cmd>SessionRestore<CR>", { desc = "Restore session for cwd" }) -- restore last workspace session for current directory
-    keymap.set("n", "<leader>ws", "<cmd>SessionSave<CR>", { desc = "Save session for auto session root dir" }) -- save workspace session for current working directory
+    keymap.set("n", "<leader>wr", "<cmd>AutoSession restore<CR>", { desc = "Restore session for cwd" })
+    keymap.set("n", "<leader>ws", "<cmd>AutoSession save<CR>",    { desc = "Save session for cwd" })
   end,
 }


### PR DESCRIPTION
The auto-session plugin has updated its API and command names, and the config shows deprecation warnings. The following changed:
- auto_restore_enabled = false → auto_restore = false
- auto_session_suppress_dirs = { ... } → suppressed_dirs = { ... }
- :SessionSave / :SessionRestore → :AutoSession save / :AutoSession restore

Hopefully this helps anyone else setting up Neovim following along, and thanks a lot for the video!